### PR TITLE
v1.2.6

### DIFF
--- a/docs/pages/security.mdx
+++ b/docs/pages/security.mdx
@@ -4,7 +4,9 @@ import AnchorModal from '@/components/AnchorModal'
 
 # Security Guidelines
 
-ACAP adheres to strict security practices as defined by its technology stack, starting from its initial 1.0 version. When extending ACAP to add or enhance features, please ensure continued compliance with these security standards.
+ACAP adheres to strict security practices and development patterns defined by its technology stack <u>"_while considering the limited options of its standard-pricing tier cloud services_"</u> starting from its initial 1.0 version.
+
+Please ensure continued compliance with these security standards when extending ACAP to add or enhance new features while actively considering its currently available plans and options.
 
 <Callout type="error" emoji="☠️">
 **NOTE:** Further enhancements and feature updates to the initial [**ACAP 1.0**](/changelog/#version-1-acap-10) version may introduce new requirements to address additional use cases. Please ensure that security measures meet the expectations outlined in these new requirements.


### PR DESCRIPTION
- Docs: appeal to use security best practices and development patterns while considering ACAP's currently available (standard-plan) tech stacks, cloud services, and architecture