### PR TITLE
fix: display the appropriate last commit timestamp per page

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -19,9 +19,10 @@ jobs:
       OPENGRAPH_IMAGE_URL: ${{ secrets.OPENGRAPH_IMAGE_URL }}
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: 'dev'
+          fetch-depth: 0
       - name: Use NodeJS v20.15.0
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -19,9 +19,10 @@ jobs:
       OPENGRAPH_IMAGE_URL: ${{ secrets.OPENGRAPH_IMAGE_URL }}
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
       - name: Use NodeJS v20.15.0
         uses: actions/setup-node@v3
         with:
@@ -82,7 +83,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Use NodeJS v20.15.0
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/pull-images.yml
+++ b/.github/workflows/pull-images.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Fetch and check out latest tag
         run: |


### PR DESCRIPTION
Chore: fetch all history for all tags and branches - fixes displaying the appropriate last commit timestamp per page