### PR TITLE
chore: display acap 2.0 and 2.1 bulletin pdf samples

### DIFF
--- a/docs/pages/articles/pdf-development.mdx
+++ b/docs/pages/articles/pdf-development.mdx
@@ -152,8 +152,16 @@ When creating new bulletin layouts that significantly differ from the existing o
 
 ## Sample bulletin (JPEG) Layouts
 
-JPEG Picture References (from R5)
+JPEG bulletin picture references (from DA RFO 5) and ACAP-generated bulletin PDFs
 
-- Seasonal bulletin - | [link](https://www.facebook.com/daamiarfo5/photos/pb.100081488360994.-2207520000/1592305051122245/?type=3) | [mirror](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/images/pdf_development_seasonal_picture_layout.png) | [acap-pdf](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/files/pdf_development_seasonal_acap.pdf) |
-- 10-day bulletin - | [link](https://www.facebook.com/photo.php?fbid=300180632708213&set=pb.100081488360994.-2207520000&type=3) | [mirror](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/images/pdf_development_10day_picture_layout.png) | [acap-pdf](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/files/pdf_development_10day_acap.pdf) |
-- Special Weather Forecast bulletin - | [link](https://www.facebook.com/photo.php?fbid=329712193088390&set=pb.100081488360994.-2207520000&type=3) | [mirror](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/images/pdf_development_cyclone_picture_layout.png) | [acap-pdf](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/files/pdf_development_cyclone_acap.pdf) |
+<br />
+
+<div className="text-sm">
+
+| Bulletin Type | JPEG Picture | JPEG Picture (mirror) | ACAP 1.0 PDF | ACAP 2.0 PDF | ACAP 2.1 PDF |
+| --- | :---: | :---: | :---: | :---: | :---: |
+| Seasonal | [link](https://www.facebook.com/daamiarfo5/photos/pb.100081488360994.-2207520000/1592305051122245/?type=3) | [mirror](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/images/pdf_development_seasonal_picture_layout.png) | [acap-1.0-pdf](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/files/pdf_development_seasonal_acap.pdf) <br /> <div className="text-xs">(single page)</div> | [acap-2.0-pdf](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/files/pdf_development_seasonal_acap_2.0.pdf) <br />  <div className="text-xs">(multiple pages)</div> | [acap-2.1-pdf](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/files/pdf_development_seasonal_acap_2.1.pdf)
+| 10-Day | [link](https://www.facebook.com/photo.php?fbid=300180632708213&set=pb.100081488360994.-2207520000&type=3) | [mirror](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/images/pdf_development_10day_picture_layout.png) | [acap-1.0-pdf](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/files/pdf_development_10day_acap.pdf) | - | [acap-2.1-pdf](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/files/pdf_development_10day_acap_2.1.pdf) |
+| Special Weather Forecast | [link](https://www.facebook.com/photo.php?fbid=329712193088390&set=pb.100081488360994.-2207520000&type=3) | [mirror](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/images/pdf_development_cyclone_picture_layout.png) | [acap-1.0-pdf](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/files/pdf_development_cyclone_acap.pdf) | - | - |
+
+</div>


### PR DESCRIPTION
- Chore: display ACAP 2.0 (Seasonal) and 2.1 (Seasonal, 10-day) bulletin PDF samples in the [/articles/pdf-development](https://acaptutorials.github.io/articles/pdf-development/) page