### PR TITLE
v1.4.1

### DIFF
--- a/docs/pages/articles/pdf-development.mdx
+++ b/docs/pages/articles/pdf-development.mdx
@@ -158,10 +158,11 @@ JPEG bulletin picture references (from DA RFO 5) and ACAP-generated bulletin PDF
 
 <div className="text-sm">
 
-| Bulletin Type | JPEG Picture | JPEG Picture (mirror) | ACAP 1.0 PDF | ACAP 2.0 PDF | ACAP 2.1 PDF |
+| Bulletin Type | JPEG Picture | JPEG Picture <br /> (mirror) | ACAP 1.0 PDF | ACAP 2.0 PDF | ACAP 2.1 PDF |
 | --- | :---: | :---: | :---: | :---: | :---: |
 | Seasonal | [link](https://www.facebook.com/daamiarfo5/photos/pb.100081488360994.-2207520000/1592305051122245/?type=3) | [mirror](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/images/pdf_development_seasonal_picture_layout.png) | [acap-1.0-pdf](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/files/pdf_development_seasonal_acap.pdf) <br /> <div className="text-xs">(single page)</div> | [acap-2.0-pdf](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/files/pdf_development_seasonal_acap_2.0.pdf) <br />  <div className="text-xs">(multiple pages)</div> | [acap-2.1-pdf](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/files/pdf_development_seasonal_acap_2.1.pdf)
 | 10-Day | [link](https://www.facebook.com/photo.php?fbid=300180632708213&set=pb.100081488360994.-2207520000&type=3) | [mirror](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/images/pdf_development_10day_picture_layout.png) | [acap-1.0-pdf](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/files/pdf_development_10day_acap.pdf) | - | [acap-2.1-pdf](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/files/pdf_development_10day_acap_2.1.pdf) |
 | Special Weather Forecast | [link](https://www.facebook.com/photo.php?fbid=329712193088390&set=pb.100081488360994.-2207520000&type=3) | [mirror](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/images/pdf_development_cyclone_picture_layout.png) | [acap-1.0-pdf](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/files/pdf_development_cyclone_acap.pdf) | - | - |
+| Special "General" <br /> Weather Forecast | - | - | - | [acap-2.0-pdf](https://raw.githubusercontent.com/acaptutorials/acaptutorials.github.io/assets/files/pdf_development_cyclone_general_acap_2.0.pdf) <br /> <div className="text-xs">(outside PAR, <br /> no wind signal)</div> | - |
 
 </div>


### PR DESCRIPTION
- chore: display acap 2.0 and 2.1 bulletin pdf samples, [PR #110](https://github.com/acaptutorials/acaptutorials.github.io/pull/110)
- chore: display acap 2.0 special general bulletin pdf sample, [PR #111](https://github.com/acaptutorials/acaptutorials.github.io/pull/111) 