### PR TITLE
fix: localhost typo

### DIFF
--- a/docs/pages/announcements/firebase-storage-2024.mdx
+++ b/docs/pages/announcements/firebase-storage-2024.mdx
@@ -211,7 +211,7 @@ The [ACAP 2.0 codebase](https://github.com/amia-cis/acap-v2) contains known secu
 - **Review the Firestore security rules** to restrict direct database writes.
 - **Check for XSS vulnerabilities** in crop recommendations and apply sanitization.
 - **Monitor database writes** for unstructured or excessive storage.
-- 👉 **Be mindful of ACAP's [Security Guidelines](/security) and [Security Best Practices](http://localhost:3000/articles/security-bestpractices/)** when <u>developing new features</u>.
+- 👉 **Be mindful of ACAP's [Security Guidelines](/security) and [Security Best Practices](/articles/security-bestpractices/)** when <u>developing new features</u>.
 
 </Callout>
 

--- a/docs/pages/security.mdx
+++ b/docs/pages/security.mdx
@@ -122,8 +122,9 @@ The [ACAP Developer Security Best Practices Checklist](/articles/security-bestpr
 ### Database
 
 1. Firestore Web API [[link]](https://firebase.google.com/docs/firestore/quickstart)
-2. Firestore REST APIs [[link]](https://firebase.google.com/docs/firestore/use-rest-api)
-3. Firestore Rules [[link]](https://firebase.google.com/docs/firestore/security/get-started)
+2. Firestore REST API (Explorer) [[link]](https://cloud.google.com/firestore/docs/reference/rest/)
+3. Firestore REST APIs [[link]](https://firebase.google.com/docs/firestore/use-rest-api)
+4. Firestore Rules [[link]](https://firebase.google.com/docs/firestore/security/get-started)
 
 ### Online Storage
 


### PR DESCRIPTION
- Fix: remove the localhost typo
- Chore: include the [Firestore REST API Explorer](https://cloud.google.com/firestore/docs/reference/rest/) in the **Security** section references