### PR TITLE
v1.4.5

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -65,4 +65,4 @@ jobs:
         with:
           args: deploy --only hosting:dev
         env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ https://hub.docker.com/r/acaptutorials/acaptutorials.github.io
 | --- | --- |
 | DOCKERHUB_USERNAME | Docker Hub username |
 | DOCKERHUB_TOKEN | Deploy token for the Docker Hub account |
-| FIREBASE_TOKEN | Firebase CI token for deployment to Firebase Hosting |
+| GCP_SA_KEY | **base64 encoded** Firebase project service account key with only the **Firebase Hosting Admin** role enabled for deploying Hosting files. |
 
 #### GitHub Variables
 
@@ -203,5 +203,3 @@ https://hub.docker.com/r/acaptutorials/acaptutorials.github.io
 @acaptutorials<br>
 20240806<br>
 20250901
-
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ## acaptutorials.github.io
 
-ACAP Bicol (ACAP 2.0) development documentation.
+Agro-Climatic Advisory Portal (ACAP) <br>
+ACAP 2.0 development documentation.
+
+> Previously known as ACAP Bicol (ACAP 1.0)
 
 Built with [Nextra](https://nextra.site/), a modern static site generation framework running on NextJS.
 

--- a/docs/pages/changelog.mdx
+++ b/docs/pages/changelog.mdx
@@ -49,7 +49,7 @@ This page summarizes the features and enhancements of major ACAP versions, exten
 
 ### Glossary of Terms
 
-- [ACAP 1.0](#version-1-acap-10) serves as the base model of the Agro-Climatic Advisory Portal (ACAP). Initially made for the Bicol region, it provides dynamic features setup support for other regional provinces. It served as the active ACAP version until ACAP 2.0.
+- [ACAP 1.0](#version-1-acap-10) serves as the base model of the Agro-Climatic Advisory Portal (ACAP). Initially made for the Bicol region, it also provides dynamic features setup support for other regional provinces. It served as the active ACAP version until ACAP 2.0.
 - [ACAP 2.0](#version-2-acap-20) and beyond is an extension of the Agro-Climatic Advisory Portal (ACAP), a Climate Information System, <u><i>expanding</i></u>, <u><i>enhancing</i></u>, and <u><i>building upon</i></u> the initial [ACAP 1.0](#version-1-acap-10) version.
    > ACAP 2.0 builds upon ACAP 1.0 rather than replacing it. It enhances and expands the original system while maintaining its core foundation.
 
@@ -143,9 +143,9 @@ _March - December 2022_
 ACAP 1.0's last stable version is Release/Tag version [**v9.5.6**](https://github.com/amia-cis/climate-services-webportal-v1/releases/tag/v9.5.6), accessible in the **climate-services-webportal-v1** and **acap-v2** code repositories.
 </Callout>
 
-Version 1.0 marks the initial ACAP Bicol release used as a base model and template for subsequent developer training and sharing with other regions in the succeeding years starting on [**July 2023**](https://uplbfi.org/?p=2097).
+Version 1.0 marks the initial ACAP Bicol release, serving as a base model and template for subsequent developer training and regional adoption in the years following [**July 2023**](https://uplbfi.org/?p=2097).
 
-Developed with a Security-first approach, ACAP 1.0 especially notes common Firestore security pitfalls and keeps a watchful eye on Cross-Site Scripting (XSS) attacks since it uses What-You-See-Is-What-You-Get (WYSIWYG) HTML input for crop recommendations and PDF generation.
+Developed with a security-first approach, ACAP 1.0 emphasizes common Firestore security pitfalls and includes safeguards against Cross-Site Scripting (XSS) vulnerabilities, particularly in modules that use WYSIWYG-based HTML input for crop recommendations and PDF generation. Originally built for ACAP Bicol, the system was designed with a flexible and modular backend to support potential cross-regional expansion.
 
 It has the following features, strictly following and is tested compatible with the recommended [Security](/security) and [Server](/directories/server) guidelines:
 

--- a/docs/pages/changelog.mdx
+++ b/docs/pages/changelog.mdx
@@ -63,7 +63,7 @@ As of <u>July 2024</u>, **ACAP 2.0**, which includes new features and upgrades, 
 
 ### Version 2 (ACAP 2.0)
 
-_June 2024 - December 2024_
+_October 2023 - December 2024_
 
 Versions from 2.0+ highlight improvements and newly added features, expanding and enhancing the initial [ACAP](#version-1-acap-10) version.
 
@@ -137,6 +137,8 @@ Version 2.0 and later versions may have new requirements that will thrive on new
 
 ### Version 1 (ACAP 1.0)
 
+_March - December 2022_
+
 <Callout type="info" emoji="ℹ️">
 ACAP 1.0's last stable version is Release/Tag version [**v9.5.6**](https://github.com/amia-cis/climate-services-webportal-v1/releases/tag/v9.5.6), accessible in the **climate-services-webportal-v1** and **acap-v2** code repositories.
 </Callout>
@@ -150,8 +152,6 @@ It has the following features, strictly following and is tested compatible with 
 <div className="text-semibold text-sm text-slate-500 no-underline">
 
 #### Added
-
-_March - December 2022_
 
 1. Login and User Authentication
 2. User (Admin) Accounts Management


### PR DESCRIPTION
- Fix: correct the ACAP 2.0 development start date (October 2023), [PR #119](https://github.com/acaptutorials/acaptutorials.github.io/pull/119)